### PR TITLE
[feature] Add folder navigation and breadcrumbs

### DIFF
--- a/web/src/pages/dashboard/index.tsx
+++ b/web/src/pages/dashboard/index.tsx
@@ -85,7 +85,9 @@ const Dashboard: React.FC = () => {
     }
   }, [upload])
 
-  console.log('what is parent', { parent, selected, data, params })
+  useEffect(() => {
+    refetch()
+  }, [parent, params])
 
   const fetch = (pagination?: TablePaginationConfig, filters?: Record<string, FilterValue | null>, sorter?: SorterResult<any> | SorterResult<any>[]) => {
     setParams({
@@ -203,7 +205,7 @@ const Dashboard: React.FC = () => {
             if (row.type === 'folder') {
               setParent(row.id)
               setBreadcrumbs([...breadcrumbs, { id: row.id, name: row.name }])
-              fetch()
+              setParams({ ...params, parent_id: row.id || undefined })
             }
           }}>
             {component} {value}
@@ -254,7 +256,6 @@ const Dashboard: React.FC = () => {
     <Navbar user={me?.user} />
     <Layout.Content className="container">
       <Row>
-        {parent}
         <Col md={{ span: 20, offset: 2 }} span={24}>
           <Typography.Paragraph>
             <Breadcrumb>
@@ -265,7 +266,7 @@ const Dashboard: React.FC = () => {
                       setParent(crumb.id)
                       const selectedCrumbIdx = breadcrumbs.findIndex(item => item.id === crumb.id)
                       setBreadcrumbs(breadcrumbs.slice(0, selectedCrumbIdx + 1))
-                      fetch()
+                      setParams({ ...params, parent_id: crumb.id || undefined })
                     }}>
                       {crumb.name}
                     </Button>


### PR DESCRIPTION
What this PR does is changing the `parent` when the user clicks on a row of item type `folder`. Also adds breadcrumbs.

It works well enough I think? Note that when fetching the items on root/home, all the children/grandchild folders will also be fetched.

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/12206156/132994786-f7baad45-3c67-47b2-9b97-7f33a52af95b.png">

Further improvements that I can think of:

- Moving `parent` out of state to the URL. So `http://localhost:3000/dashboard?folder=<folder-uuid>`, where folder is `parent`.
- If you do the above though, we might need an additional endpoint for the breadcrumbs? Since right now the breadcrumbs are calculated on the frontend.