### PR TITLE
update feature/redis

### DIFF
--- a/server/src/service/Cache.ts
+++ b/server/src/service/Cache.ts
@@ -5,9 +5,6 @@ export class Redis {
   private redis: IOredis
 
   private constructor() {
-    if (!process.env.REDIS_URI) {
-      throw new Error('REDIS_URI is not defined')
-    }
     this.redis = new IORedis(process.env.REDIS_URI)
   }
 


### PR DESCRIPTION
IORedis permits using nothing as an argument to create a new instance, using their default options ; why bother not doing so?