### PR TITLE
(Docker) Fix postgresql password generation

### DIFF
--- a/install.docker.sh
+++ b/install.docker.sh
@@ -21,7 +21,7 @@ then
   read -p "Enter your PORT: " PORT
   PORT="${PORT:=4000}"
 
-  DB_PASSWORD=$(node -e "console.log(require('crypto').randomBytes(48).toString('base64'));")
+  DB_PASSWORD=$(node -e "console.log(require('crypto').randomBytes(48).toString('hex'));")
 
   echo "ENV=$ENV" > docker/.env
   echo "PORT=$PORT" >> docker/.env


### PR DESCRIPTION
This makes the script generate a password that this code line can use without issue:
https://github.com/mgilangjanuar/teledrive/blob/6c7ef8fd9e7d2e5faba917569e08856a8b402f87/docker/docker-compose.yml#L20
With base64 it could create "/" and "+" characters that can difer with the url causing teledrive can't connect to the database.