### PR TITLE
Fix illegal characters

### DIFF
--- a/install.docker.new.sh
+++ b/install.docker.new.sh
@@ -23,7 +23,7 @@ then
   read -p "Enter your PORT: " PORT
   PORT="${PORT:=4000}"
 
-  DB_PASSWORD=$(node -e "console.log(require('crypto').randomBytes(48).toString('base64'));")
+  DB_PASSWORD=$(node -e "console.log(require('crypto').randomBytes(48).toString('hex'));")
 
   echo "ENV=$ENV" > docker/.env
   echo "PORT=$PORT" >> docker/.env


### PR DESCRIPTION
Base64 produces illegal filenames for `DB_PASSWORD`

Like \ or =

Reverting it back to hex, so no illegal characters are set.