### PR TITLE
add deployment to fly.io

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,0 +1,17 @@
+FROM node:18.16.0 as build
+ARG REACT_APP_TG_API_ID
+ARG REACT_APP_TG_API_HASH
+
+WORKDIR /apps
+
+COPY yarn.lock .
+COPY package.json .
+COPY api/package.json api/package.json
+COPY web/package.json web/package.json
+COPY docker/.env.fly .env
+RUN yarn cache clean
+RUN yarn install --network-timeout 1000000
+COPY . .
+RUN yarn workspaces run build
+
+CMD [ "yarn", "start" ]

--- a/docker/.env.fly.example
+++ b/docker/.env.fly.example
@@ -1,0 +1,13 @@
+ADMIN_USERNAME = #your username (@blablabbla)
+ENV=develop
+REACT_APP_API_URL=https://example.fly.dev
+CACHE_FILES_LIMIT=20GB
+DATABASE_URL=postgres://username:password@host/dbname
+REACT_APP_TG_API_HASH=
+REACT_APP_TG_API_ID=
+TG_API_HASH=
+TG_API_ID=
+REDIS_URI= #optional
+# change the values below
+API_JWT_SECRET=WDpojmXTH4ZPl3N2khUPPcAezLLpc8Mm 
+FILES_JWT_SECRET=nWHVW3arIdjC8Vy3g9rU2N6sKWmfPp7Z

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,37 @@
+# fly.toml app configuration file generated for tldrive on 2023-04-28T00:35:23+08:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "tldrive" #your app name
+kill_signal = "SIGINT"
+kill_timeout = 5
+primary_region = "sin" #your region
+processes = []
+
+[build]
+
+[env]
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 4000 #internal port
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443


### PR DESCRIPTION
If you already have an account on [fly.io](https://fly.io) and have installed [flyctl](https://fly.io/docs/hands-on/install-flyctl/), follow these steps:

1. Clone this repository.
2. Copy and rename `.env.fly.example` to `.env.fly`, and then modify its contents.
3. Run `flyctl launch`, do not confirm the deployment, and then check `fly.toml` to ensure that the internal port is `4000`.
4. Increase the RAM by running the command `fly scale memory 512` because this application requires at least 512MB of memory.
5. If everything is correct, run the command `flyctl deploy --dockerfile Dockerfile.fly`.