### PR TITLE
Delete files from Telegram chat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 
 FROM node:18.16.0 as build
-RUN echo Fix error: `cd docker && chmod -R 777 data'
 ARG REACT_APP_TG_API_ID
 ARG REACT_APP_TG_API_HASH
 WORKDIR /apps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-
 FROM node:18.16.0 as build
 ARG REACT_APP_TG_API_ID
 ARG REACT_APP_TG_API_HASH
+
 WORKDIR /apps
 
 COPY yarn.lock .
@@ -10,8 +10,6 @@ COPY api/package.json api/package.json
 COPY web/package.json web/package.json
 COPY docker/.env .
 RUN yarn cache clean
-RUN yarn install
-RUN yarn global add prisma
-RUN npx browserslist@latest --update-db
+RUN yarn install --network-timeout 1000000
 COPY . .
-RUN export NODE_OPTIONS="--openssl-legacy-provider --no-experimental-fetch" && yarn workspaces run build
+RUN yarn workspaces run build

--- a/install.docker.new.sh
+++ b/install.docker.new.sh
@@ -38,56 +38,18 @@ then
   sleep 2
   docker compose exec teledrive yarn workspace api prisma migrate reset
   docker compose exec teledrive yarn workspace api prisma migrate deploy
-
-echo "If you get an error like this:
-
-A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
-
-Migration name: 20220525012308_add_password_files
-
-Database error code: 42P01
-
-Database error:
-ERROR: relation \"files\" does not exist
-
-DbError { severity: \"ERROR\", parsed_severity: Some(Error), code: SqlState(E42P01), message: \"relation \\\"files\\\" does not exist\", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some(\"namespace.c\"), line: Some(432), routine: Some(\"RangeVarGetRelidExtended\") }
-
-Please run the following commands to resolve the issue:
-
-cd docker
-docker compose exec teledrive yarn workspace api prisma migrate reset
-docker compose exec teledrive yarn workspace api prisma migrate deploy
-
-Only run these commands once as these commands reset the database only use for initial setup. If you have any more errors please report on github 
-https://github.com/mgilangjanuar/teledrive/issues
-
-Enjoy your deployment!
-"
-
 else
-git pull origin main
+  git pull origin main
 
-export $(cat docker/.env | xargs)
+  export $(cat docker/.env | xargs)
 
-cd docker
-docker compose down
-docker compose up --build --force-recreate -d
-sleep 2
-docker compose up -d
-docker scompose exec teledrive yarn workspace api prisma migrate deploy || {
-  echo "
-  If you encounter the following error after deploying:
-  failed to solve: error from sender: open /home/user/teledrive/docker/data: permission denied
-  Please run the following commands:
   cd docker
-  sudo chmod -R 777 data
-  Then, you can go back to the root directory of the project with
-  cd ../
-  You can then start the script again, and the issue should be resolved. Note that the permissions will be reset, so you will need to perform this step every time you redeploy the docker.
-  "
-  exit 1
-}
-git reset --hard
-git clean -f
-git pull origin main
+  docker compose down
+  docker compose up --build --force-recreate -d
+  sleep 2
+  docker compose up -d
+  docker compose exec teledrive yarn workspace api prisma migrate deploy
+  git reset --hard
+  git clean -f
+  git pull origin main
 fi

--- a/web/src/pages/dashboard/components/Remove.tsx
+++ b/web/src/pages/dashboard/components/Remove.tsx
@@ -1,5 +1,5 @@
 import { WarningOutlined } from '@ant-design/icons'
-import { Modal, Typography } from 'antd'
+import { Checkbox, Form, Modal, Typography } from 'antd'
 import React, { useState } from 'react'
 import { req } from '../../../utils/Fetcher'
 
@@ -15,13 +15,13 @@ const Remove: React.FC<Props> = ({
   onFinish }) => {
 
   const [loadingRemove, setLoadingRemove] = useState<boolean>()
-  // const [deleteMessage, setDeleteMessage] = useState<boolean>()
+  const [deleteMessage, setDeleteMessage] = useState<boolean>()
 
   const remove = async (ids: string[]) => {
     setLoadingRemove(true)
     try {
       await Promise.all(ids.map(async id => await req.delete(`/files/${id}`, {
-        // params: { deleteMessage: deleteMessage ? 'true' : undefined }
+        params: { deleteMessage: deleteMessage ? 'true' : undefined }
       })))
     } catch (error) {
       // ignore
@@ -31,6 +31,15 @@ const Remove: React.FC<Props> = ({
     setSelectDeleted([])
     setLoadingRemove(false)
     onFinish?.(newData)
+  }
+
+  const folderSelected = (): boolean => {
+    let hasFolder = false
+    selectDeleted?.forEach(element => {
+      if (element.type === 'folder')
+        hasFolder = true
+    })
+    return hasFolder
   }
 
   return <Modal visible={!!selectDeleted?.length}
@@ -43,11 +52,12 @@ const Remove: React.FC<Props> = ({
     <Typography.Paragraph>
       Are you sure to delete {selectDeleted?.length > 1 ? `${selectDeleted?.length} objects` : selectDeleted?.[0]?.name.replace(/\.part0*\d+$/, '') }?
     </Typography.Paragraph>
-    {/* <Form.Item>
-      <Checkbox checked={deleteMessage} onChange={({ target }) => setDeleteMessage(target.checked)}>
-        Delete from Saved Messages too
-      </Checkbox>
-    </Form.Item> */}
+    { !folderSelected() ?
+      <Form.Item>
+        <Checkbox checked={deleteMessage} onChange={({ target }) => setDeleteMessage(target.checked)}>
+        Delete from <code>Telegram</code> too? This cannot be reverted.
+        </Checkbox>
+      </Form.Item> : '' }
   </Modal>
 }
 


### PR DESCRIPTION
**Delete files from Telegram chats**
Re-enabled the checkbox for deleting files from the Telegram source chat.
The checkbox does not show itself when a folder to delete is selected. This is because of optimization reasons.
A fix to the "remove" method in Files.ts allows now to remove files in Telegram that are saved in Saved Messages, Channels, or Groups.

**Errors more verbose**
Errors that occur when a file gets uploaded are now shown to the user. A possible contribution to #469.