### PR TITLE
Support for Fragment numbers

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@ideasio/add-to-homescreen-react": "^1.0.10",
     "antd": "4.18.3",
-    "antd-country-phone-input": "^4.3.1",
+    "antd-country-phone-input": "^4.5.1",
     "axios": "^1.3.5",
     "base64url": "^3.0.1",
     "clipboardy": "^2.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "axios": "^1.3.5",
     "base64url": "^3.0.1",
     "clipboardy": "^2.3.0",
+    "get-user-locale": "^2.2.1",
     "js-cookie": "^3.0.1",
     "less": "^4.1.2",
     "lessc": "^1.0.2",

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -61,7 +61,8 @@ const Login: React.FC<Props> = ({ me }) => {
         const client = await anonymousTelegramClient.connect()
         if (phoneCodeHash) {
           const { phoneCodeHash: newPhoneCodeHash, timeout } = await client.invoke(new Api.auth.ResendCode({
-            phoneNumber, phoneCodeHash }))
+            phoneNumber, phoneCodeHash
+          }))
           const session = client.session.save() as any
           localStorage.setItem('session', session)
           data = { phoneCodeHash: newPhoneCodeHash, timeout }
@@ -409,9 +410,11 @@ const Login: React.FC<Props> = ({ me }) => {
               _qrCodeSignIn().then(resolve).catch(reject)
             } else {
               const invitationCode = location.search.replace('?code=', '')
-              req.post('/auth/qrCodeSignIn', { invitationCode }, { headers: {
-                'Authorization': `Bearer ${qrCode.accessToken}`
-              } }).then(({ data }) => resolve(data)).catch(reject)
+              req.post('/auth/qrCodeSignIn', { invitationCode }, {
+                headers: {
+                  'Authorization': `Bearer ${qrCode.accessToken}`
+                }
+              }).then(({ data }) => resolve(data)).catch(reject)
             }
           }).then((data: any) => {
             // console.log(data)
@@ -535,7 +538,8 @@ const Login: React.FC<Props> = ({ me }) => {
                       borderRadius: '4px',
                       fontSize: '1.2rem',
                       background: currentTheme === 'dark' ? 'rgba(255, 255, 255, 0.04)' : undefined,
-                      border: '1px solid rgba(0, 0, 0, 0.3)' }} />
+                      border: '1px solid rgba(0, 0, 0, 0.3)'
+                    }} />
                     {countdown ? <Typography.Paragraph type="secondary">Re-send in {countdown}s...</Typography.Paragraph> : <Typography.Paragraph>
                       <Button type="link" onClick={() => sendCode()}>Re-send code</Button>
                     </Typography.Paragraph>}

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -16,6 +16,7 @@ import { computeCheck } from 'telegram/Password'
 import en from 'world_countries_lists/data/countries/en/world.json'
 import { fetcher, req } from '../utils/Fetcher'
 import { anonymousTelegramClient, telegramClient } from '../utils/Telegram'
+import { getUserLocale } from 'get-user-locale'
 
 interface Props {
   me?: any
@@ -34,9 +35,10 @@ const Login: React.FC<Props> = ({ me }) => {
   const [phoneCodeHash, setPhoneCodeHash] = useState<string>()
   const [needPassword, setNeedPassword] = useState<boolean>()
   const [method, setMethod] = useState<'phoneNumber' | 'qrCode'>('phoneNumber')
-  const { data: _ } = useSWRImmutable('/utils/ipinfo', fetcher, { onSuccess: ({ ipinfo }) => setPhoneData(phoneData?.short ? phoneData : { short: ipinfo?.country || 'ID' }) })
+  const { data: _ } = useSWRImmutable('/utils/ipinfo', fetcher, { onSuccess: ({ ipinfo }) => setPhoneData(phoneData?.short ? phoneData : { short: ipinfo?.country || country }) })
   const [qrCode, setQrCode] = useState<{ loginToken: string, accessToken?: string, session?: string }>()
   const { currentTheme } = useThemeSwitcher()
+  const country = getUserLocale()?.substring(3, 5)?.toString() || 'ID'
 
   // useEffect(() => {
   //   // init config

--- a/web/src/pages/dashboard/components/TableFiles.tsx
+++ b/web/src/pages/dashboard/components/TableFiles.tsx
@@ -15,7 +15,7 @@ import {
   TeamOutlined,
   VideoCameraOutlined
 } from '@ant-design/icons'
-import { Descriptions, Menu, Modal, Table, Tag, Typography } from 'antd'
+import { Descriptions, Image, Menu, Modal, Table, Tag, Typography } from 'antd'
 import { SorterResult } from 'antd/lib/table/interface'
 import moment from 'moment'
 import prettyBytes from 'pretty-bytes'
@@ -70,6 +70,8 @@ const TableFiles: React.FC<Props> = ({
   const { data: user } = useSWR(showDetails ? `/users/${showDetails.user_id}` : null, fetcher)
   const { data: filesParts } = useSWR(showDetails ? `/files?name.like=${showDetails.name.replace(/\.part0*\d+$/, '')}&user_id=${showDetails.user_id}&parent_id${showDetails.parent_id ? `=${showDetails.parent_id}` : '=null'}${tab === 'shared' ? '&shared=1' : ''}` : null, fetcher)
   const pasteEnabled = useRef<boolean | null>(null)
+  const [visible, setVisible] = useState(false)
+  const [linkRaw, setLinkRaw] = useState<string>('')
 
   useEffect(() => {
     pasteEnabled.current = Boolean(selected?.length && action)
@@ -123,6 +125,14 @@ const TableFiles: React.FC<Props> = ({
           key="details"
           onClick={() => setShowDetails(popup?.row)}>Details</Menu.Item>
         {tab === 'mine' && <>
+          {popup?.row.type === 'image' ? <Menu.Item {...baseProps}
+            icon={<FileImageOutlined />}
+            key="viewImage"
+            onClick={() => {
+              setLinkRaw(`${process.env.REACT_APP_API_URL || window.location.origin}/api/v1/files/${popup?.row.id}?raw=1&password=${sessionStorage.getItem(`pass-${popup?.row.id}`)}`)
+              setVisible(true)
+              console.log('row', popup?.row)
+            }}>View Image</Menu.Item> : ''}
           <Menu.Item {...baseProps}
             icon={<EditOutlined />}
             key="rename"
@@ -341,6 +351,19 @@ const TableFiles: React.FC<Props> = ({
         } : undefined} />
     </DndProvider>
     <ContextMenu />
+    <Image
+      width={200}
+      style={{ display: 'none' }}
+      src={linkRaw}
+      preview={{
+        visible,
+        src: linkRaw,
+        onVisibleChange: value => {
+          setLinkRaw('')
+          setVisible(value)
+        },
+      }}
+    />
     <Modal title={<Typography.Text ellipsis><Icon type={showDetails?.type} /> {showDetails?.name.replace(/\.part0*\d+$/, '')}</Typography.Text>}
       visible={Boolean(showDetails)}
       onCancel={() => setShowDetails(undefined)}


### PR DESCRIPTION
**Support for Fragment numbers**
Added a new checkbox for switching to Fragment's anonymous numbers (prefix +888).
This is a possible solution for the feature request #483.

**Fetch user's default locale**
If the "/utils/info" fetcher doesn't obtain any country info, before applying the default value "ID" it tries to fetch the user's browser default locale. This is mostly useful for users that run Teledrive into their private network.

**Update antd-country-phone-input dependency**