### PR TITLE
Make some directories configrable

### DIFF
--- a/api/src/api/v1/Files.ts
+++ b/api/src/api/v1/Files.ts
@@ -19,7 +19,7 @@ import { Endpoint } from '../base/Endpoint'
 import { Auth, AuthMaybe } from '../middlewares/Auth'
 import { Messages } from './Messages'
 
-const CACHE_DIR = `${__dirname}/../../../../.cached`
+const CACHE_DIR = process.env.CACHE_DIR || `${__dirname}/../../../../.cached`
 
 @Endpoint.API()
 export class Files {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -84,12 +84,14 @@ app.use(async (err: { status?: number, body?: Record<string, any> }, req: Reques
   return res.status(err.status || 500).send(err.body || { error: 'Something error', details: serializeError(err) })
 })
 
+const WEB_SERVE_DIR = process.env.WEB_SERVE_DIR || path.join(__dirname, '..', '..', 'web', 'build')
+
 // serve web
-app.use(serveStatic(path.join(__dirname, '..', '..', 'web', 'build')))
+app.use(serveStatic(`${WEB_SERVE_DIR}`))
 app.use((req: Request, res: Response) => {
   try {
     if (req.headers['accept'] !== 'application/json') {
-      return res.sendFile(path.join(__dirname, '..', '..','web', 'build', 'index.html'))
+      return res.sendFile(path.join(`${WEB_SERVE_DIR}`, 'index.html'))
     }
     return res.status(404).send({ error: 'Not found' })
   } catch (error) {

--- a/docs/docs/Installation/manual.md
+++ b/docs/docs/Installation/manual.md
@@ -66,6 +66,8 @@ variables in `./api/.env`, you can copy from `./api/.env.example`
   | ---------------------- | -------- | ----------------------------------------------------- |
   | ENV                    | no       | Hide the logs for production, default: develop        |
   | PORT                   | no       | Port for running API, default: 4000                   |
+  | CACHE_DIR              | no       | Directory to cache saved files                        |
+  | WEB_SERVE_DIR          | no       | Directory to serve the static web build, only needed when you build web workspace separately in somewhere else |
   | TG_API_ID              | yes      | Application ID from your Telegram App                 |
   | TG_API_HASH            | yes      | Application hash from Telegram App                    |
   | ADMIN_USERNAME         | yes      | Telegram username of the admin TeleDrive              |


### PR DESCRIPTION
1. Use user specified CACHE_DIR if exists
This is useful if say user deploy the service as systemd unit, then cache can be wrote to standard systemd CacheDirectory for example. (/var/cache/xxx)

2. Use user specified WEB_SERVE_DIR if exists
For some building system, (nix specific here), we build the two web and api worspaces separately, so web build isn't necessarily of __dirname/../../web/build, make that configurable would be nice.